### PR TITLE
fix: final_check FAIL 승격 + notify_slack 정리

### DIFF
--- a/.claude/hooks/final_check.sh
+++ b/.claude/hooks/final_check.sh
@@ -103,7 +103,11 @@ STATUS_COUNT=$(status_hook_count 2>/dev/null || true)
 if [ -n "$README_COUNT" ]; then
   echo "  README 문서화: ${README_COUNT}개"
   if [ -n "$SETTINGS_HOOKS" ] && [ "$README_COUNT" -ne "$SETTINGS_HOOKS" ] 2>/dev/null; then
-    warn "README($README_COUNT) ≠ settings.local($SETTINGS_HOOKS) — 문서 드리프트"
+    if [ "$MODE" = "--full" ]; then
+      fail "README($README_COUNT) ≠ settings.local($SETTINGS_HOOKS) — 문서 드리프트 (--full 모드: FAIL 승격)"
+    else
+      warn "README($README_COUNT) ≠ settings.local($SETTINGS_HOOKS) — 문서 드리프트"
+    fi
   else
     echo "  [OK] README hook 개수 일치"
   fi
@@ -114,7 +118,11 @@ fi
 if [ -n "$STATUS_COUNT" ]; then
   echo "  STATUS 문서화: ${STATUS_COUNT}개"
   if [ -n "$SETTINGS_HOOKS" ] && [ "$STATUS_COUNT" -ne "$SETTINGS_HOOKS" ] 2>/dev/null; then
-    warn "STATUS($STATUS_COUNT) ≠ settings.local($SETTINGS_HOOKS) — 문서 드리프트"
+    if [ "$MODE" = "--full" ]; then
+      fail "STATUS($STATUS_COUNT) ≠ settings.local($SETTINGS_HOOKS) — 문서 드리프트 (--full 모드: FAIL 승격)"
+    else
+      warn "STATUS($STATUS_COUNT) ≠ settings.local($SETTINGS_HOOKS) — 문서 드리프트"
+    fi
   else
     echo "  [OK] STATUS hook 개수 일치"
   fi
@@ -196,7 +204,12 @@ echo ""
 # 7. TASKS/HANDOFF 최신화 확인
 echo "--- 7. TASKS/HANDOFF 갱신 확인 ---"
 STATE_DIR="$PROJECT_DIR/90_공통기준/agent-control/state"
-MARKER="$STATE_DIR/write_marker.flag"
+MARKER="$STATE_DIR/write_marker.json"
+LEGACY_MARKER="$STATE_DIR/write_marker.flag"
+# 레거시 .flag 파일도 확인 (마이그레이션 기간)
+if [ ! -f "$MARKER" ] && [ -f "$LEGACY_MARKER" ]; then
+  MARKER="$LEGACY_MARKER"
+fi
 
 if [ -f "$MARKER" ]; then
   MARKER_EPOCH=$(file_mtime "$MARKER")

--- a/.claude/hooks/notify_slack.sh
+++ b/.claude/hooks/notify_slack.sh
@@ -2,12 +2,12 @@
 # Notification hook — Slack 알림 연동 (스팸 방지 포함)
 source "$(dirname "$0")/hook_common.sh" 2>/dev/null
 INPUT=$(cat)
-# bash-only JSON 파싱 (python3 의존 제거, #34457 Windows hooks 멈춤 대응)
-MSG=$(echo "$INPUT" | sed -n 's/.*"message"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+# safe_json_get 사용 (sed 단독 파싱 대체, GPT+Claude 합의 2026-04-11)
+MSG=$(echo "$INPUT" | safe_json_get "message" 2>/dev/null)
 MSG="${MSG:-알림}"
 
 # 스팸 방지: 동일 메시지 60초 내 중복 전송 차단
-DEDUP_FILE="$HOME/Desktop/업무리스트/.claude/hooks/.notify_dedup"
+DEDUP_FILE="$PROJECT_ROOT/.claude/hooks/.notify_dedup"
 HASH=$(echo "$MSG" | md5sum | cut -d' ' -f1)
 NOW=$(date +%s)
 
@@ -23,5 +23,13 @@ echo "$HASH" > "$DEDUP_FILE"
 echo "$NOW" >> "$DEDUP_FILE"
 
 hook_log "Notification" "$MSG" 2>/dev/null
-# Slack 발송
-python3 "$HOME/Desktop/업무리스트/90_공통기준/업무관리/slack_notify.py" --message "$MSG"
+# Slack 발송 — python3/python 동적 감지
+PY_CMD=""
+if command -v python3 >/dev/null 2>&1; then
+  PY_CMD="python3"
+elif command -v python >/dev/null 2>&1; then
+  PY_CMD="python"
+fi
+if [ -n "$PY_CMD" ]; then
+  $PY_CMD "$PROJECT_ROOT/90_공통기준/업무관리/slack_notify.py" --message "$MSG"
+fi

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -181,6 +181,15 @@
         ]
       },
       {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/handoff_archive.sh"
+          }
+        ]
+      },
+      {
         "matcher": "Read|Grep|Glob|Bash|Write|Edit|MultiEdit",
         "hooks": [
           {


### PR DESCRIPTION
## Summary
- final_check.sh: --full 모드에서 README/STATUS↔settings 불일치 FAIL 승격
- notify_slack.sh: sed→safe_json_get, $HOME→$PROJECT_ROOT, python 동적 감지
- settings.local.json: handoff_archive.sh 복원

## Test plan
- [x] smoke_test.sh 95/95 ALL PASS
- [x] GPT 판정: 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)